### PR TITLE
User supplied http.Client

### DIFF
--- a/spotify.go
+++ b/spotify.go
@@ -87,6 +87,10 @@ func New(httpClient *http.Client) *Client {
 	return &Client{httpClient: httpClient}
 }
 
+func NewDefault() *Client {
+	return New(http.DefaultClient)
+}
+
 func (client *Client) SearchTracks(srch string, page int) (*SearchTracksResponse, error) {
 	url := fmt.Sprintf("http://ws.spotify.com/search/1/track.json?q=%s&page=%d", url.QueryEscape(srch), page)
 	var data SearchTracksResponse

--- a/spotify.go
+++ b/spotify.go
@@ -14,6 +14,7 @@ import (
 )
 
 type Client struct {
+	httpClient *http.Client
 }
 
 type SearchTracksResponse struct {
@@ -79,8 +80,8 @@ type Artist struct {
 	URI        string `json:"href,omitempty"`
 }
 
-func New() *Client {
-	return &Client{}
+func New(httpClient *http.Client) *Client {
+	return &Client{httpClient: httpClient}
 }
 
 func (client *Client) SearchTracks(srch string, page int) (*SearchTracksResponse, error) {
@@ -117,7 +118,7 @@ func (client *Client) SearchArtists(srch string, page int) (*SearchArtistsRespon
 }
 
 func (client *Client) doSearch(url string, data interface{}) error {
-	resp, err := http.Get(url)
+	resp, err := client.httpClient.Get(url)
 
 	if err != nil {
 		return fmt.Errorf("Search failed with http error: %s", err.Error())
@@ -172,7 +173,7 @@ func (client *Client) LookupArtist(uri string) (*Artist, error) {
 
 func (client *Client) doLookup(uri string, data interface{}) error {
 	url := fmt.Sprintf("http://ws.spotify.com/lookup/1/.json?uri=%s", url.QueryEscape(uri))
-	resp, err := http.Get(url)
+	resp, err := client.httpClient.Get(url)
 
 	if err != nil {
 		return fmt.Errorf("Lookup failed with http error: %s", err.Error())

--- a/spotify.go
+++ b/spotify.go
@@ -81,6 +81,9 @@ type Artist struct {
 }
 
 func New(httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
 	return &Client{httpClient: httpClient}
 }
 

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSearch(t *testing.T) {
 
-	s := New(&http.Client{})
+	s := New(nil)
 
 	_, err := s.SearchArtists("foo", 0)
 

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestSearch(t *testing.T) {
 
-	s := New(nil)
+	s := NewDefault()
 
 	_, err := s.SearchArtists("foo", 0)
 

--- a/spotify_test.go
+++ b/spotify_test.go
@@ -1,0 +1,29 @@
+package spotify
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestSearch(t *testing.T) {
+
+	s := New(&http.Client{})
+
+	_, err := s.SearchArtists("foo", 0)
+
+	if err != nil {
+		t.Errorf("error not nil: ", err)
+	}
+}
+
+func TestLookUp(t *testing.T) {
+
+	s := New(&http.Client{})
+
+	_, err := s.LookupTrack("spotify:track:6NmXV4o6bmp704aPGyTVVG")
+
+	if err != nil {
+		t.Errorf("error not nil: ", err)
+	}
+
+}


### PR DESCRIPTION
GAE, for example, offers benefits if you use an app engine specific
http.Client when you do requests.
